### PR TITLE
BREAKING: Add master/loop/playback properties and lazy-load units/events

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,18 +84,53 @@ Creates an instance backed by a WebAssembly service.
 
 ### Properties
 
-| Property      | Type                     | Description                                |
-| ------------- | ------------------------ | ------------------------------------------ |
-| `channels`    | `2`                      | Output channel count (always stereo)       |
-| `sampleRate`  | `44100`                  | Output sample rate in Hz (always 44.1 kHz) |
-| `name`        | `string \| null`         | Song title (Shift-JIS decoded)             |
-| `comment`     | `string \| null`         | Song comment (Shift-JIS decoded)           |
-| `duration`    | `number \| null`         | Total duration in seconds                  |
-| `loopStart`   | `number \| null`         | Loop start position in seconds             |
-| `loopEnd`     | `number \| null`         | Loop end position in seconds               |
-| `currentTime` | `number`                 | Current playback position in seconds       |
-| `units`       | `readonly PxtoneUnit[]`  | Instrument tracks                          |
-| `events`      | `readonly PxtoneEvent[]` | Automation event list                      |
+#### Audio output
+
+| Property     | Type    | Description                                |
+| ------------ | ------- | ------------------------------------------ |
+| `channels`   | `2`     | Output channel count (always stereo)       |
+| `sampleRate` | `44100` | Output sample rate in Hz (always 44.1 kHz) |
+
+#### Metadata (available after `read()`)
+
+| Property  | Type             | Description                      |
+| --------- | ---------------- | -------------------------------- |
+| `name`    | `string \| null` | Song title (Shift-JIS decoded)   |
+| `comment` | `string \| null` | Song comment (Shift-JIS decoded) |
+
+#### Master (available after `read()`)
+
+| Property          | Type             | Description               |
+| ----------------- | ---------------- | ------------------------- |
+| `ticksPerBeat`    | `number \| null` | Ticks per beat            |
+| `beatsPerMeasure` | `number \| null` | Beats per measure         |
+| `beatTempo`       | `number \| null` | Tempo in BPM              |
+| `measureCount`    | `number \| null` | Total number of measures  |
+| `tickCount`       | `number \| null` | Total length in ticks     |
+| `duration`        | `number \| null` | Total duration in seconds |
+
+#### Loop (available after `read()`)
+
+| Property           | Type             | Description                     |
+| ------------------ | ---------------- | ------------------------------- |
+| `loopStartMeasure` | `number \| null` | Loop start position in measures |
+| `loopEndMeasure`   | `number \| null` | Loop end position in measures   |
+| `loopStart`        | `number \| null` | Loop start position in seconds  |
+| `loopEnd`          | `number \| null` | Loop end position in seconds    |
+
+### Playback
+
+| Property      | Type     | Description                          |
+| ------------- | -------- | ------------------------------------ |
+| `currentTick` | `number` | Current playback position in ticks   |
+| `currentTime` | `number` | Current playback position in seconds |
+
+#### Song data
+
+| Property | Type                     | Description           |
+| -------- | ------------------------ | --------------------- |
+| `units`  | `readonly PxtoneUnit[]`  | Instrument tracks     |
+| `events` | `readonly PxtoneEvent[]` | Automation event list |
 
 ### Methods
 

--- a/src/Pxtone.ts
+++ b/src/Pxtone.ts
@@ -17,6 +17,7 @@ import {
   service_get_sample_rate,
   service_get_text_comment,
   service_get_text_name,
+  service_get_ticks_per_beat,
   service_get_unit_count,
   service_get_unit_name,
   service_get_unit_played,
@@ -275,16 +276,21 @@ export class Pxtone {
   #channels: 2;
   #sampleRate: 44100;
 
-  #state: "idle" | "ready" | "streaming" | "disposed" = "idle";
-
   #name: string | null = null;
   #comment: string | null = null;
-  #secondsPerMeasure: number | null = null;
-  #measureNum: number | null = null;
-  #repeatMeasure: number | null = null;
-  #lastMeasure: number | null = null;
 
+  #ticksPerBeat: number | null = null;
+  #beatsPerMeasure: number | null = null;
+  #beatTempo: number | null = null;
+  #measureCount: number | null = null;
+  #secondsPerMeasure: number | null = null;
+
+  #loopStartMeasure: number | null = null;
+  #loopEndMeasure: number | null = null;
+
+  #state: "idle" | "ready" | "streaming" | "disposed" = "idle";
   #currentFrame = 0;
+
   #units: readonly PxtoneUnit[] = Object.freeze([]);
   #events: readonly PxtoneEvent[] = Object.freeze([]);
 
@@ -334,12 +340,68 @@ export class Pxtone {
     return this.#comment;
   }
 
+  /** Ticks per beat. `null` before {@link read}. */
+  get ticksPerBeat(): number | null {
+    if (this.#state !== "ready" && this.#state !== "streaming") {
+      return null;
+    }
+    return this.#ticksPerBeat!;
+  }
+
+  /** Beats per measure. `null` before {@link read}. */
+  get beatsPerMeasure(): number | null {
+    if (this.#state !== "ready" && this.#state !== "streaming") {
+      return null;
+    }
+    return this.#beatsPerMeasure!;
+  }
+
+  /** Tempo in beats per minute. `null` before {@link read}. */
+  get beatTempo(): number | null {
+    if (this.#state !== "ready" && this.#state !== "streaming") {
+      return null;
+    }
+    return this.#beatTempo!;
+  }
+
+  /** Total number of measures in the song. `null` before {@link read}. */
+  get measureCount(): number | null {
+    if (this.#state !== "ready" && this.#state !== "streaming") {
+      return null;
+    }
+    return this.#measureCount!;
+  }
+
+  /** Loop start position in measures. `null` before {@link read}. */
+  get loopStartMeasure(): number | null {
+    if (this.#state !== "ready" && this.#state !== "streaming") {
+      return null;
+    }
+    return this.#loopStartMeasure!;
+  }
+
+  /** Loop end position in measures. `null` before {@link read}. */
+  get loopEndMeasure(): number | null {
+    if (this.#state !== "ready" && this.#state !== "streaming") {
+      return null;
+    }
+    return this.#loopEndMeasure!;
+  }
+
+  /** Total length of the song in ticks. `null` before {@link read}. */
+  get tickCount(): number | null {
+    if (this.#state !== "ready" && this.#state !== "streaming") {
+      return null;
+    }
+    return this.#measureCount! * this.#beatsPerMeasure! * this.#ticksPerBeat!;
+  }
+
   /** Total song duration in seconds. `null` before {@link read}. */
   get duration(): number | null {
     if (this.#state !== "ready" && this.#state !== "streaming") {
       return null;
     }
-    return this.#measureNum! * this.#secondsPerMeasure!;
+    return this.#measureCount! * this.#secondsPerMeasure!;
   }
 
   /** Loop start position in seconds. `null` before {@link read}. */
@@ -347,7 +409,7 @@ export class Pxtone {
     if (this.#state !== "ready" && this.#state !== "streaming") {
       return null;
     }
-    return this.#repeatMeasure! * this.#secondsPerMeasure!;
+    return this.#loopStartMeasure! * this.#secondsPerMeasure!;
   }
 
   /** Loop end position in seconds. `null` before {@link read}. */
@@ -355,35 +417,44 @@ export class Pxtone {
     if (this.#state !== "ready" && this.#state !== "streaming") {
       return null;
     }
-    return this.#lastMeasure! * this.#secondsPerMeasure!;
+    return this.#loopEndMeasure! * this.#secondsPerMeasure!;
   }
 
-  /**
-   * Current playback position in seconds, updated as each chunk is pulled
-   * from the stream returned by {@link stream}.
-   */
+  /** Current playback position in ticks, updated as each chunk is pulled from the stream. */
+  get currentTick(): number {
+    if (this.#state !== "ready" && this.#state !== "streaming") {
+      return 0;
+    }
+    const spm = this.#secondsPerMeasure!;
+    const tpm = this.#beatsPerMeasure! * this.#ticksPerBeat!;
+    return Math.round(this.#resolveCurrentFrame() * tpm / (spm * this.#sampleRate));
+  }
+
+  /** Current playback position in seconds, updated as each chunk is pulled from the stream. */
   get currentTime(): number {
     if (this.#state !== "ready" && this.#state !== "streaming") {
       return 0;
     }
+    return this.#resolveCurrentFrame() / this.#sampleRate;
+  }
+
+  #resolveCurrentFrame(): number {
     const sampleRate = this.#sampleRate;
     const currentFrame = this.#currentFrame;
-    const lastMeasure = this.#lastMeasure!;
-    const repeatMeasure = this.#repeatMeasure!;
-    if (repeatMeasure !== 0) {
+    const loopEndMeasure = this.#loopEndMeasure!;
+    const loopStartMeasure = this.#loopStartMeasure!;
+    if (loopStartMeasure !== 0) {
       const spm = this.#secondsPerMeasure!;
-      const loopEndFrame = Math.round(lastMeasure * spm * sampleRate);
-      const loopStartFrame = Math.round(repeatMeasure * spm * sampleRate);
+      const loopEndFrame = Math.round(loopEndMeasure * spm * sampleRate);
+      const loopStartFrame = Math.round(loopStartMeasure * spm * sampleRate);
       const loopLength = Math.round(
-        (lastMeasure - repeatMeasure) * spm * sampleRate,
+        (loopEndMeasure - loopStartMeasure) * spm * sampleRate,
       );
       if (loopLength > 0 && currentFrame > loopEndFrame) {
-        const position = loopStartFrame +
-          (currentFrame - loopEndFrame) % loopLength;
-        return position / sampleRate;
+        return loopStartFrame + (currentFrame - loopEndFrame) % loopLength;
       }
     }
-    return currentFrame / sampleRate;
+    return currentFrame;
   }
 
   /** Ordered list of instrument tracks in the loaded song. */
@@ -414,10 +485,13 @@ export class Pxtone {
   #release() {
     this.#name = null;
     this.#comment = null;
+    this.#ticksPerBeat = null;
+    this.#beatsPerMeasure = null;
+    this.#beatTempo = null;
     this.#secondsPerMeasure = null;
-    this.#measureNum = null;
-    this.#repeatMeasure = null;
-    this.#lastMeasure = null;
+    this.#measureCount = null;
+    this.#loopStartMeasure = null;
+    this.#loopEndMeasure = null;
     this.#currentFrame = 0;
     for (let i = 0; i < this.#units.length; ++i) {
       releaseUnitPtr(this.#units[i]);
@@ -457,13 +531,14 @@ export class Pxtone {
     }
     this.#name = this.#readText(service_get_text_name);
     this.#comment = this.#readText(service_get_text_comment);
-    const beatTempo = service_get_beat_tempo(this.#ptr);
-    const beatsPerMeasure = service_get_beats_per_measure(this.#ptr);
-    this.#secondsPerMeasure = (beatsPerMeasure * 60) / beatTempo;
-    this.#measureNum = service_get_measure_num(this.#ptr);
-    this.#repeatMeasure = service_get_repeat_measure(this.#ptr);
-    const lastMeasure = service_get_last_measure(this.#ptr);
-    this.#lastMeasure = lastMeasure !== 0 ? lastMeasure : this.#measureNum;
+    this.#ticksPerBeat = service_get_ticks_per_beat(this.#ptr);
+    this.#beatsPerMeasure = service_get_beats_per_measure(this.#ptr);
+    this.#beatTempo = service_get_beat_tempo(this.#ptr);
+    this.#secondsPerMeasure = (this.#beatsPerMeasure * 60) / this.#beatTempo;
+    this.#measureCount = service_get_measure_num(this.#ptr);
+    this.#loopStartMeasure = service_get_repeat_measure(this.#ptr);
+    const loopEndMeasure = service_get_last_measure(this.#ptr);
+    this.#loopEndMeasure = loopEndMeasure !== 0 ? loopEndMeasure : this.#measureCount;
     this.#currentFrame = 0;
     this.#units = this.#loadUnits();
     this.#events = this.#loadEvents(this.#units);

--- a/src/Pxtone.ts
+++ b/src/Pxtone.ts
@@ -291,8 +291,8 @@ export class Pxtone {
   #state: "idle" | "ready" | "streaming" | "disposed" = "idle";
   #currentFrame = 0;
 
-  #units: readonly PxtoneUnit[] = Object.freeze([]);
-  #events: readonly PxtoneEvent[] = Object.freeze([]);
+  #units: readonly PxtoneUnit[] | null = null;
+  #events: readonly PxtoneEvent[] | null = null;
 
   constructor() {
     this.#ptr = service_new();
@@ -459,11 +459,31 @@ export class Pxtone {
 
   /** Ordered list of instrument tracks in the loaded song. */
   get units(): readonly PxtoneUnit[] {
+    if (this.#units !== null) {
+      return this.#units;
+    }
+    if (this.#state === "idle" || this.#state === "disposed") {
+      this.#events = Object.freeze([]);
+      this.#units = Object.freeze([]);
+    } else {
+      this.#units = this.#loadUnits();
+      this.#events = this.#loadEvents(this.#units);
+    }
     return this.#units;
   }
 
   /** Ordered list of automation events in the loaded song. */
   get events(): readonly PxtoneEvent[] {
+    if (this.#events !== null) {
+      return this.#events;
+    }
+    if (this.#state === "idle" || this.#state === "disposed") {
+      this.#units = Object.freeze([]);
+      this.#events = Object.freeze([]);
+    } else {
+      this.#units = this.#loadUnits();
+      this.#events = this.#loadEvents(this.#units);
+    }
     return this.#events;
   }
 
@@ -493,11 +513,13 @@ export class Pxtone {
     this.#loopStartMeasure = null;
     this.#loopEndMeasure = null;
     this.#currentFrame = 0;
-    for (let i = 0; i < this.#units.length; ++i) {
-      releaseUnitPtr(this.#units[i]);
+    if (this.#units !== null) {
+      for (let i = 0; i < this.#units.length; ++i) {
+        releaseUnitPtr(this.#units[i]);
+      }
     }
-    this.#units = Object.freeze([]);
-    this.#events = Object.freeze([]);
+    this.#units = null;
+    this.#events = null;
   }
 
   /**
@@ -540,8 +562,8 @@ export class Pxtone {
     const loopEndMeasure = service_get_last_measure(this.#ptr);
     this.#loopEndMeasure = loopEndMeasure !== 0 ? loopEndMeasure : this.#measureCount;
     this.#currentFrame = 0;
-    this.#units = this.#loadUnits();
-    this.#events = this.#loadEvents(this.#units);
+    this.#units = null;
+    this.#events = null;
     this.#state = "ready";
   }
 

--- a/tests/pxtone_test.ts
+++ b/tests/pxtone_test.ts
@@ -272,22 +272,43 @@ Deno.test("Pxtone getters are guarded by state", async () => {
 
   // --- idle ---
 
+  assertEquals(pxtone.ticksPerBeat, null);
+  assertEquals(pxtone.beatsPerMeasure, null);
+  assertEquals(pxtone.beatTempo, null);
+  assertEquals(pxtone.measureCount, null);
+  assertEquals(pxtone.tickCount, null);
   assertEquals(pxtone.duration, null);
+
+  assertEquals(pxtone.loopStartMeasure, null);
+  assertEquals(pxtone.loopEndMeasure, null);
   assertEquals(pxtone.loopStart, null);
   assertEquals(pxtone.loopEnd, null);
+  assertEquals(pxtone.currentTick, 0);
   assertEquals(pxtone.currentTime, 0);
+
   assertEquals(pxtone.units.length, 0);
   assertEquals(pxtone.events.length, 0);
+
   assertThrows(() => pxtone.stream());
 
   // --- ready ---
 
   pxtone.read(fileData);
 
+  assertNotEquals(pxtone.ticksPerBeat, null);
+  assertNotEquals(pxtone.beatsPerMeasure, null);
+  assertNotEquals(pxtone.beatTempo, null);
+  assertNotEquals(pxtone.measureCount, null);
+  assertNotEquals(pxtone.tickCount, null);
   assertNotEquals(pxtone.duration, null);
+
+  assertNotEquals(pxtone.loopStartMeasure, null);
+  assertNotEquals(pxtone.loopEndMeasure, null);
   assertNotEquals(pxtone.loopStart, null);
   assertNotEquals(pxtone.loopEnd, null);
+  assertEquals(pxtone.currentTick, 0);
   assertEquals(pxtone.currentTime, 0);
+
   assert(pxtone.units.length > 0);
   assert(pxtone.events.length > 0);
 
@@ -298,12 +319,23 @@ Deno.test("Pxtone getters are guarded by state", async () => {
   await reader.read();
   await reader.read();
 
+  assertNotEquals(pxtone.ticksPerBeat, null);
+  assertNotEquals(pxtone.beatsPerMeasure, null);
+  assertNotEquals(pxtone.beatTempo, null);
+  assertNotEquals(pxtone.measureCount, null);
+  assertNotEquals(pxtone.tickCount, null);
   assertNotEquals(pxtone.duration, null);
+
+  assertNotEquals(pxtone.loopStartMeasure, null);
+  assertNotEquals(pxtone.loopEndMeasure, null);
   assertNotEquals(pxtone.loopStart, null);
   assertNotEquals(pxtone.loopEnd, null);
+  assert(pxtone.currentTick > 0);
   assert(pxtone.currentTime > 0);
+
   assert(pxtone.units.length > 0);
   assert(pxtone.events.length > 0);
+
   assertThrows(() => pxtone.read(fileData));
   assertThrows(() => pxtone.stream());
 
@@ -312,10 +344,20 @@ Deno.test("Pxtone getters are guarded by state", async () => {
   reader.releaseLock();
   await stream.cancel();
 
+  assertNotEquals(pxtone.ticksPerBeat, null);
+  assertNotEquals(pxtone.beatsPerMeasure, null);
+  assertNotEquals(pxtone.beatTempo, null);
+  assertNotEquals(pxtone.measureCount, null);
+  assertNotEquals(pxtone.tickCount, null);
   assertNotEquals(pxtone.duration, null);
+
+  assertNotEquals(pxtone.loopStartMeasure, null);
+  assertNotEquals(pxtone.loopEndMeasure, null);
   assertNotEquals(pxtone.loopStart, null);
   assertNotEquals(pxtone.loopEnd, null);
+  assert(pxtone.currentTick > 0);
   assert(pxtone.currentTime > 0);
+
   assert(pxtone.units.length > 0);
   assert(pxtone.events.length > 0);
 
@@ -323,10 +365,20 @@ Deno.test("Pxtone getters are guarded by state", async () => {
 
   pxtone.clear();
 
+  assertEquals(pxtone.ticksPerBeat, null);
+  assertEquals(pxtone.beatsPerMeasure, null);
+  assertEquals(pxtone.beatTempo, null);
+  assertEquals(pxtone.measureCount, null);
+  assertEquals(pxtone.tickCount, null);
   assertEquals(pxtone.duration, null);
+
+  assertEquals(pxtone.loopStartMeasure, null);
+  assertEquals(pxtone.loopEndMeasure, null);
   assertEquals(pxtone.loopStart, null);
   assertEquals(pxtone.loopEnd, null);
+  assertEquals(pxtone.currentTick, 0);
   assertEquals(pxtone.currentTime, 0);
+
   assertEquals(pxtone.units.length, 0);
   assertEquals(pxtone.events.length, 0);
 
@@ -334,10 +386,20 @@ Deno.test("Pxtone getters are guarded by state", async () => {
 
   pxtone[Symbol.dispose]();
 
+  assertEquals(pxtone.ticksPerBeat, null);
+  assertEquals(pxtone.beatsPerMeasure, null);
+  assertEquals(pxtone.beatTempo, null);
+  assertEquals(pxtone.measureCount, null);
+  assertEquals(pxtone.tickCount, null);
   assertEquals(pxtone.duration, null);
+
+  assertEquals(pxtone.loopStartMeasure, null);
+  assertEquals(pxtone.loopEndMeasure, null);
   assertEquals(pxtone.loopStart, null);
   assertEquals(pxtone.loopEnd, null);
+  assertEquals(pxtone.currentTick, 0);
   assertEquals(pxtone.currentTime, 0);
+
   assertEquals(pxtone.units.length, 0);
   assertEquals(pxtone.events.length, 0);
 });


### PR DESCRIPTION
- Add master parameter properties: `ticksPerBeat`, `beatsPerMeasure`, `beatTempo`
- Add length properties: `measureCount` (measures), `tickCount` (ticks)
- Add loop-position properties in measures: `loopStartMeasure`, `loopEndMeasure`
- Add `currentTick` — tick-domain counterpart of `currentTime`
- Lazy-load `units` and `events`: initialized on first getter access rather than
  eagerly in `read()`, reset to `null` by `read()` and `clear()`
