### PR TITLE
BREAKING: Refactor PCM output to f32-planar AudioData

### DIFF
--- a/src/Pxtone.ts
+++ b/src/Pxtone.ts
@@ -1,3 +1,5 @@
+import { pcmToAudioData } from "./pcm.ts";
+
 import {
   alloc,
   dealloc,
@@ -570,8 +572,8 @@ export class Pxtone {
   }
 
   /**
-   * Returns a `ReadableStream` that yields signed 16-bit interleaved PCM chunks
-   * as {@link AudioData} objects (format `"s16"`).
+   * Returns a `ReadableStream` that yields PCM chunks as {@link AudioData} objects
+   * (format `"f32-planar"`).
    *
    * Only one stream may be active at a time. The stream ends naturally when the
    * song finishes (or the loop point is reached with `loop: false`).
@@ -654,17 +656,12 @@ export class Pxtone {
               controller.close();
               return;
             }
-            const audioData = new AudioData({
-              format: "s16",
+            const audioData = pcmToAudioData({
+              data: new Int16Array(memory.buffer, memPtr, chunkBytes / 2),
               sampleRate,
               numberOfFrames,
               numberOfChannels: channels,
               timestamp: Math.round(currentFrame * 1_000_000 / sampleRate),
-              data: new Int16Array(
-                memory.buffer,
-                memPtr,
-                chunkBytes / 2,
-              ),
             });
             controller.enqueue(audioData);
             setCurrentFrame(currentFrame);
@@ -687,18 +684,27 @@ export class Pxtone {
    * Decodes a `.ptnoise` file and returns the rendered PCM as an `AudioBuffer`.
    *
    * @param buffer - Raw `.ptnoise` file bytes.
-   * @returns A promise that resolves with the decoded `AudioBuffer`.
+   * @returns A promise that resolves with the decoded `AudioData`.
    * @throws {Error} If the instance has been disposed.
    */
   decodeNoiseData(
     buffer: ArrayBuffer | Uint8Array,
-  ): Promise<AudioBuffer> {
+  ): Promise<AudioData> {
     if (this.#state === "disposed") {
       return Promise.reject(new Error("Pxtone instance has been disposed"));
     }
     try {
       const { pcm, channels, sampleRate } = this.#renderNoise(buffer);
-      return Promise.resolve(this.#pcmToAudioBuffer(pcm, channels, sampleRate));
+      const numberOfFrames = pcm.length / (channels * 2);
+      return Promise.resolve(
+        pcmToAudioData({
+          data: new Int16Array(pcm.buffer, pcm.byteOffset, pcm.length / 2),
+          sampleRate,
+          numberOfFrames,
+          numberOfChannels: channels,
+          timestamp: 0,
+        }),
+      );
     } catch (e) {
       return Promise.reject(e);
     }
@@ -788,30 +794,5 @@ export class Pxtone {
       dealloc(dataPtr, bytes.length);
       dealloc(outSamplesLen, 4);
     }
-  }
-
-  #pcmToAudioBuffer(
-    pcm: Uint8Array,
-    channels: number,
-    sampleRate: number,
-  ): AudioBuffer {
-    const totalSamples = pcm.length / (channels * 2);
-    const audioBuffer = new AudioBuffer({
-      numberOfChannels: channels,
-      length: totalSamples,
-      sampleRate,
-    });
-    const channelData: Float32Array<ArrayBuffer>[] = [];
-    for (let i = 0; i < channels; ++i) {
-      channelData.push(audioBuffer.getChannelData(i));
-    }
-    const int16 = new Int16Array(pcm.buffer, pcm.byteOffset, pcm.length / 2);
-    for (let i = 0; i < totalSamples; i++) {
-      for (let ch = 0; ch < channels; ch++) {
-        const s = int16[i * channels + ch];
-        channelData[ch][i] = s / (s >= 0 ? 32767 : 32768);
-      }
-    }
-    return audioBuffer;
   }
 }

--- a/src/Pxtone.ts
+++ b/src/Pxtone.ts
@@ -613,11 +613,7 @@ export class Pxtone {
         loop ? 1 : 0,
       ) !== 0
     ) {
-      return new ReadableStream({
-        start(controller) {
-          controller.error(new Error("service_moo_preparation failed"));
-        },
-      });
+      throw new Error("service_moo_preparation failed");
     }
 
     this.#state = "streaming";
@@ -635,16 +631,39 @@ export class Pxtone {
     const ptr = this.#ptr;
     let currentFrame = startSample;
 
+    let abortHandler: (() => void) | undefined;
+    const cleanupAbort = () => {
+      if (signal && abortHandler !== undefined) {
+        signal.removeEventListener("abort", abortHandler);
+        abortHandler = undefined;
+      }
+    };
+
     return new ReadableStream<AudioData>({
+      start(controller) {
+        if (signal == null) return;
+        if (signal.aborted) {
+          onStreamEnd();
+          controller.error(signal.reason);
+          return;
+        }
+        abortHandler = () => {
+          cleanupAbort();
+          onStreamEnd();
+          controller.error(signal.reason);
+        };
+        signal.addEventListener("abort", abortHandler);
+      },
       pull(controller) {
         try {
-          signal?.throwIfAborted();
           if (isDisposed()) {
+            cleanupAbort();
             onStreamEnd();
             controller.error(new Error("Pxtone instance has been disposed"));
             return;
           }
           if (service_is_end_vomit(ptr) !== 0) {
+            cleanupAbort();
             onStreamEnd();
             controller.close();
             return;
@@ -652,6 +671,7 @@ export class Pxtone {
           const memPtr = alloc(chunkBytes);
           try {
             if (service_moo(ptr, memPtr, chunkBytes) === 0) {
+              cleanupAbort();
               onStreamEnd();
               controller.close();
               return;
@@ -670,11 +690,13 @@ export class Pxtone {
             dealloc(memPtr, chunkBytes);
           }
         } catch (e) {
+          cleanupAbort();
           onStreamEnd();
           throw e;
         }
       },
       cancel() {
+        cleanupAbort();
         onStreamEnd();
       },
     }, { highWaterMark });

--- a/src/pcm.ts
+++ b/src/pcm.ts
@@ -1,0 +1,28 @@
+/**
+ * Converts signed 16-bit interleaved PCM to an {@link AudioData} with `f32-planar` format.
+ */
+export function pcmToAudioData(init: {
+  data: Int16Array;
+  sampleRate: number;
+  numberOfFrames: number;
+  numberOfChannels: number;
+  timestamp: number;
+}): AudioData {
+  const { data, sampleRate, numberOfFrames, numberOfChannels, timestamp } = init;
+  const f32 = new Float32Array(numberOfFrames * numberOfChannels);
+  for (let i = 0; i < numberOfFrames; i++) {
+    for (let ch = 0; ch < numberOfChannels; ch++) {
+      const s = data[i * numberOfChannels + ch];
+      f32[ch * numberOfFrames + i] = s / 0x8000;
+    }
+  }
+  return new AudioData({
+    format: "f32-planar",
+    sampleRate,
+    numberOfFrames,
+    numberOfChannels,
+    timestamp,
+    data: f32,
+    transfer: [f32.buffer],
+  });
+}

--- a/tests/pxtone_test.ts
+++ b/tests/pxtone_test.ts
@@ -8,65 +8,45 @@ import { Pxtone } from "../src/Pxtone.ts";
 
 const projectRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
 
-// Mock AudioBuffer (used by decodeNoiseData via new AudioBuffer({...}))
-class MockAudioBuffer {
-  #data: Float32Array[];
-  readonly numberOfChannels: number;
-  readonly length: number;
-  readonly sampleRate: number;
-
-  constructor(
-    { numberOfChannels = 1, length, sampleRate }: {
-      numberOfChannels?: number;
-      length: number;
-      sampleRate: number;
-    },
-  ) {
-    this.numberOfChannels = numberOfChannels;
-    this.length = length;
-    this.sampleRate = sampleRate;
-    this.#data = Array.from(
-      { length: numberOfChannels },
-      () => new Float32Array(length),
-    );
-  }
-
-  getChannelData(channel: number): Float32Array {
-    return this.#data[channel];
-  }
-}
-
-// Mock AudioData (used by stream() via new AudioData({...}))
-const audioDataPcm = new WeakMap<object, ArrayBuffer>();
-
+// Mock AudioData (used by stream() and decodeNoiseData() via new AudioData({...}))
 class MockAudioData {
-  constructor(
-    init: {
-      format: string;
-      sampleRate: number;
-      numberOfFrames: number;
-      numberOfChannels: number;
-      timestamp: number;
-      data: BufferSource;
-    },
-  ) {
+  readonly format: string;
+  readonly sampleRate: number;
+  readonly numberOfFrames: number;
+  readonly numberOfChannels: number;
+  readonly timestamp: number;
+  readonly data: ArrayBuffer;
+
+  constructor(init: {
+    format: string;
+    sampleRate: number;
+    numberOfFrames: number;
+    numberOfChannels: number;
+    timestamp: number;
+    data: BufferSource;
+  }) {
+    this.format = init.format;
+    this.sampleRate = init.sampleRate;
+    this.numberOfFrames = init.numberOfFrames;
+    this.numberOfChannels = init.numberOfChannels;
+    this.timestamp = init.timestamp;
     const { data } = init;
-    const buf = data instanceof ArrayBuffer
+    this.data = data instanceof ArrayBuffer
       ? data
       : data.buffer.slice(data.byteOffset, data.byteOffset + data.byteLength);
-    audioDataPcm.set(this, buf);
   }
 }
 
-(globalThis as Record<string, unknown>).AudioBuffer = MockAudioBuffer;
 (globalThis as Record<string, unknown>).AudioData = MockAudioData;
 
-function audioBufToPcm(buf: MockAudioBuffer): Uint8Array {
-  const { numberOfChannels: channels, length } = buf;
-  const int16 = new Int16Array(length * channels);
-  for (let i = 0; i < length; i++) {
+// Converts f32-planar MockAudioData back to s16 interleaved PCM for WAV comparison.
+function audioDataToPcm(audioData: MockAudioData): Uint8Array {
+  const { numberOfFrames: frames, numberOfChannels: channels, data } = audioData;
+  const f32 = new Float32Array(data);
+  const int16 = new Int16Array(frames * channels);
+  for (let i = 0; i < frames; i++) {
     for (let ch = 0; ch < channels; ch++) {
-      int16[i * channels + ch] = buf.getChannelData(ch)[i] * 32768;
+      int16[i * channels + ch] = f32[ch * frames + i] * 0x8000;
     }
   }
   return new Uint8Array(int16.buffer);
@@ -174,9 +154,7 @@ Deno.test("decoded ptcop matches reference (Pxtone)", async () => {
     while (true) {
       const { done, value } = await reader.read();
       if (done) break;
-      pcmChunks.push(
-        new Uint8Array(audioDataPcm.get(value as unknown as object)!),
-      );
+      pcmChunks.push(audioDataToPcm(value as unknown as MockAudioData));
     }
 
     const totalLen = pcmChunks.reduce((n, c) => n + c.length, 0);
@@ -235,8 +213,8 @@ Deno.test("decoded ptnoise matches reference (Pxtone)", async () => {
       continue;
     }
 
-    const buf = result as unknown as MockAudioBuffer;
-    const wav = pcmToWav(audioBufToPcm(buf), pxtone.channels, pxtone.sampleRate);
+    const buf = result as unknown as MockAudioData;
+    const wav = pcmToWav(audioDataToPcm(buf), pxtone.channels, pxtone.sampleRate);
     const expected = await Deno.readFile(join(snapshotDir, `${stem}.wav`));
     if (
       wav.length !== expected.length || wav.some((b, i) => b !== expected[i])


### PR DESCRIPTION
## Summary

- Extract s16-interleaved → f32-planar conversion into `src/pcm.ts` as `pcmToAudioData()`
- `stream()` now yields `AudioData` with format `"f32-planar"` instead of `"s16"`
- Change `decodeNoiseData()` return type from `Promise<AudioBuffer>` to `Promise<AudioData>`
- Add `abort` event listener on the `AbortSignal` passed to `stream()` so the stream closes immediately on abort, rather than waiting for the next `pull()` call
- Throw synchronously on `service_moo_preparation` failure, consistent with other error paths in `stream()`

closes https://github.com/petamoriken/PxtoneJS/issues/27

🤖 Generated with [Claude Code](https://claude.com/claude-code)