### PR TITLE
Replace tsc-based .d.ts generation with deno transpile

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -27,7 +27,6 @@
     "@deno/dnt": "jsr:@deno/dnt@^0.42.3",
     "@std/assert": "jsr:@std/assert@^1.0.19",
     "@std/toml": "jsr:@std/toml@^1.0.11",
-    "typescript": "npm:typescript@^6.0.3",
     "vite": "npm:vite@^8.0.10"
   },
   "compilerOptions": {

--- a/deno.lock
+++ b/deno.lock
@@ -13,7 +13,6 @@
     "jsr:@std/toml@^1.0.11": "1.0.11",
     "jsr:@ts-morph/bootstrap@0.27": "0.27.0",
     "jsr:@ts-morph/common@0.27": "0.27.0",
-    "npm:typescript@^6.0.3": "6.0.3",
     "npm:vite@^8.0.10": "8.0.10"
   },
   "jsr": {
@@ -344,10 +343,6 @@
     "tslib@2.8.1": {
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
     },
-    "typescript@6.0.3": {
-      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
-      "bin": true
-    },
     "vite@8.0.10": {
       "integrity": "sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==",
       "dependencies": [
@@ -368,7 +363,6 @@
       "jsr:@deno/dnt@~0.42.3",
       "jsr:@std/assert@^1.0.19",
       "jsr:@std/toml@^1.0.11",
-      "npm:typescript@^6.0.3",
       "npm:vite@^8.0.10"
     ]
   }

--- a/tools/build_dts.ts
+++ b/tools/build_dts.ts
@@ -1,61 +1,46 @@
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
-import ts from "typescript";
-
 const projectRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
 
-const compilerOptions: ts.CompilerOptions = {
-  declaration: true,
-  emitDeclarationOnly: true,
-  allowImportingTsExtensions: true,
-  allowArbitraryExtensions: true,
-  moduleResolution: ts.ModuleResolutionKind.Bundler,
-  module: ts.ModuleKind.ESNext,
-  target: ts.ScriptTarget.ESNext,
-  strict: true,
-  lib: ["lib.dom.d.ts", "lib.dom.iterable.d.ts", "lib.esnext.d.ts"],
-};
-
-let dtsContent = "";
-
-const host = ts.createCompilerHost(compilerOptions);
-host.writeFile = (fileName: string, data: string) => {
-  if (fileName.endsWith("Pxtone.d.ts")) {
-    dtsContent = data;
-  }
-};
-
-const program = ts.createProgram(
-  [join(projectRoot, "src/Pxtone.ts")],
-  compilerOptions,
-  host,
+// deno.json's lib includes deno.ns for tests, which conflicts with the bundle's
+// DOM-only target, so override compilerOptions.lib with a config just for this transpile
+const tempDir = await Deno.makeTempDir();
+const configPath = join(tempDir, "deno.json");
+await Deno.writeTextFile(
+  configPath,
+  JSON.stringify({ compilerOptions: { lib: ["dom", "dom.iterable", "esnext"] } }),
 );
 
-const emitResult = program.emit();
+const jsPath = join(tempDir, "Pxtone.js");
+const dtsPath = join(tempDir, "Pxtone.d.ts");
 
-const diagnostics = ts
-  .getPreEmitDiagnostics(program)
-  .concat(emitResult.diagnostics);
+const command = new Deno.Command(Deno.execPath(), {
+  args: [
+    "transpile",
+    join(projectRoot, "src/Pxtone.ts"),
+    "-o",
+    jsPath,
+    "--declaration",
+    "--config",
+    configPath,
+    "--quiet",
+  ],
+  stderr: "inherit",
+});
 
-let hasError = false;
-for (const diag of diagnostics) {
-  if (diag.category === ts.DiagnosticCategory.Error) {
-    const message = ts.flattenDiagnosticMessageText(diag.messageText, "\n");
-    const location = diag.file
-      ? `${diag.file.fileName}:${diag.file.getLineAndCharacterOfPosition(diag.start!).line + 1}`
-      : "unknown";
-    console.error(`error: ${location}: ${message}`);
-    hasError = true;
-  }
-}
-
-if (hasError) Deno.exit(1);
-
-if (!dtsContent) {
-  console.error("error: no .d.ts output was generated");
+const { success } = await command.output();
+if (!success) {
+  await Deno.remove(tempDir, { recursive: true });
   Deno.exit(1);
 }
+
+const dtsLines = (await Deno.readTextFile(dtsPath)).split("\n");
+const dtsContent = dtsLines
+  .filter((line) => !line.includes("<amd-module"))
+  .join("\n");
+
+await Deno.remove(tempDir, { recursive: true });
 
 const outPath = join(projectRoot, "bundle", "Pxtone.d.mts");
 await Deno.writeTextFile(outPath, dtsContent);


### PR DESCRIPTION
## Summary
- Replace the `typescript` npm package-based declaration emission in `tools/build_dts.ts` with Deno's built-in `deno transpile --declaration` command, run as a subprocess with a temporary config that overrides `compilerOptions.lib` (the project's `deno.json` includes `deno.ns` for tests, which conflicts with the DOM-only bundle types)
- Drop the now-unused `typescript` npm dependency from `deno.json` and update `deno.lock`

Verified the generated `bundle/Pxtone.d.mts` is byte-identical to the previous tsc-based output.

## Test plan
- [x] `deno task build` succeeds and produces `bundle/Pxtone.d.mts`
- [x] `deno task build:npm` succeeds and produces `npm/Pxtone.d.mts`
- [x] `deno lint --rules-exclude=no-slow-types` passes
- [x] `deno fmt --check` passes
- [x] `deno task test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)