### PR TITLE
Add version-specified bump commit to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,13 +37,6 @@ jobs:
       - name: Bump version
         run: deno run --allow-read --allow-write tools/bump_version.ts "${{ inputs.version }}"
 
-      - name: Commit version bump
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git commit -am "chore: bump version to v${{ inputs.version }}"
-          git push origin HEAD
-
       - name: Build
         run: deno task build && deno task build:npm
 
@@ -54,10 +47,13 @@ jobs:
         run: npm publish --provenance --access public
         working-directory: ./npm
 
-      - name: Tag version bump
+      - name: Commit and tag version bump
         run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git commit -am "chore: bump version to v${{ inputs.version }}"
           git tag "v${{ inputs.version }}"
-          git push origin "v${{ inputs.version }}"
+          git push origin HEAD "v${{ inputs.version }}"
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,13 +37,12 @@ jobs:
       - name: Bump version
         run: deno run --allow-read --allow-write tools/bump_version.ts "${{ inputs.version }}"
 
-      - name: Commit and tag version bump
+      - name: Commit version bump
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git commit -am "chore: bump version to v${{ inputs.version }}"
-          git tag "v${{ inputs.version }}"
-          git push origin HEAD --tags
+          git push origin HEAD
 
       - name: Build
         run: deno task build && deno task build:npm
@@ -54,6 +53,11 @@ jobs:
       - name: Publish to npm
         run: npm publish --provenance --access public
         working-directory: ./npm
+
+      - name: Tag version bump
+        run: |
+          git tag "v${{ inputs.version }}"
+          git push origin "v${{ inputs.version }}"
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,10 @@ name: Release
 
 on:
   workflow_dispatch:
+    inputs:
+      version:
+        description: Version to release (e.g. 4.1.4)
+        required: true
 
 permissions:
   contents: write
@@ -30,6 +34,17 @@ jobs:
       - name: Install Deno dependencies
         run: deno install --frozen
 
+      - name: Bump version
+        run: deno run --allow-read --allow-write tools/bump_version.ts "${{ inputs.version }}"
+
+      - name: Commit and tag version bump
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git commit -am "chore: bump version to v${{ inputs.version }}"
+          git tag "v${{ inputs.version }}"
+          git push origin HEAD --tags
+
       - name: Build
         run: deno task build && deno task build:npm
 
@@ -43,4 +58,5 @@ jobs:
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v3
         with:
+          tag_name: v${{ inputs.version }}
           files: bundle/*

--- a/tools/bump_version.ts
+++ b/tools/bump_version.ts
@@ -1,0 +1,21 @@
+const version = Deno.args[0];
+if (version === undefined || !/^\d+\.\d+\.\d+$/.test(version)) {
+  console.error("Usage: deno run --allow-read --allow-write tools/bump_version.ts <version>");
+  Deno.exit(1);
+}
+
+const denoJsonPath = "./deno.json";
+const denoJson = await Deno.readTextFile(denoJsonPath);
+await Deno.writeTextFile(
+  denoJsonPath,
+  denoJson.replace(/"version": "[^"]+"/, `"version": "${version}"`),
+);
+
+const pxtoneTsPath = "./src/Pxtone.ts";
+const pxtoneTs = await Deno.readTextFile(pxtoneTsPath);
+await Deno.writeTextFile(
+  pxtoneTsPath,
+  pxtoneTs.replace(/PxtoneJS v\d+\.\d+\.\d+/, `PxtoneJS v${version}`),
+);
+
+console.log(`Bumped version to v${version}`);


### PR DESCRIPTION
## Summary
- Add a `version` input to `workflow_dispatch` so a version can be specified when triggering a release
- Add `tools/bump_version.ts` and a step that updates the version in `deno.json` and `src/Pxtone.ts`, then commits and tags it after publishing succeeds
- Pass `tag_name` explicitly to `action-gh-release`
- Bump the version and build with it on disk first, then commit/tag only after JSR and npm publish succeed, so a failed publish never leaves main or a tag in an inconsistent state

## Note
- Immutable releases are a repository setting (Settings > General > Releases > "Enable release immutability"), not something configurable from the workflow, so it's out of scope for this PR. The current `action-gh-release` usage (default draft → upload assets → publish flow) already works fine if that setting is enabled

## Test plan
- [x] Verified `deno run --allow-read --allow-write tools/bump_version.ts <version>` locally
- [ ] Run an actual release via `workflow_dispatch` to confirm end-to-end behavior