### PR TITLE
Fix release workflow to handle branch protection and npm republish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
   id-token: write
 
 jobs:
@@ -44,16 +45,48 @@ jobs:
         run: deno publish --allow-dirty
 
       - name: Publish to npm
-        run: npm publish --provenance --access public
+        run: |
+          if npm view "pxtone@${{ inputs.version }}" version >/dev/null 2>&1; then
+            echo "Version ${{ inputs.version }} is already published to npm, skipping"
+          else
+            npm publish --provenance --access public
+          fi
         working-directory: ./npm
 
-      - name: Commit and tag version bump
+      - name: Commit version bump
+        id: bump_commit
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -b "release/v${{ inputs.version }}"
           git commit -am "chore: bump version to v${{ inputs.version }}"
-          git tag "v${{ inputs.version }}"
-          git push origin HEAD "v${{ inputs.version }}"
+          echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+          git push origin "release/v${{ inputs.version }}"
+
+      - name: Open version bump PR
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PAT }}
+        run: |
+          gh pr create \
+            --base main \
+            --head "release/v${{ inputs.version }}" \
+            --title "chore: bump version to v${{ inputs.version }}" \
+            --body "Automated version bump for release v${{ inputs.version }}."
+
+      - name: Wait for required checks
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PAT }}
+        run: gh pr checks "release/v${{ inputs.version }}" --watch --required
+
+      - name: Merge version bump PR
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PAT }}
+        run: gh pr merge "release/v${{ inputs.version }}" --merge --delete-branch
+
+      - name: Tag version bump
+        run: |
+          git tag "v${{ inputs.version }}" "${{ steps.bump_commit.outputs.sha }}"
+          git push origin "v${{ inputs.version }}"
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v3


### PR DESCRIPTION
## Summary
- The version-bump commit push to `main` was rejected by the required-status-check ruleset ("Deno CI"), since a freshly created commit has no CI run attached yet, and this repo (personal account, not an organization) cannot add bypass actors to the ruleset.
- On retry, `npm publish` errored when the version was already published, unlike `deno publish` which skips gracefully.

## Changes
- Route the version-bump commit through a real PR flow instead of pushing directly to `main`: create a `release/v<version>` branch, open a PR, wait for "Deno CI" to pass, then merge with a merge commit (so the bump commit stays in `main`'s history for tagging).
- PR creation/checks/merge use a new `RELEASE_PAT` secret instead of the default `GITHUB_TOKEN`, since GitHub Actions' recursion-prevention rule means `GITHUB_TOKEN`-triggered `pull_request` events don't start new workflow runs, so "Deno CI" would never execute otherwise.
- `npm publish` now checks `npm view` first and skips if the version is already published, matching JSR's idempotent behavior.

## Test plan
- [ ] Trigger `workflow_dispatch` with a new version: bump PR is created, "Deno CI" passes, PR auto-merges, tag + GitHub Release are created
- [ ] Re-trigger `workflow_dispatch` with an already-released version: npm publish step logs "already published, skipping" instead of failing

🤖 Generated with [Claude Code](https://claude.com/claude-code)