### PR TITLE
chore: add Deno Dependabot automation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: deno
+    directory: "/"
+    schedule:
+      interval: daily
+      time: "08:00"
+      timezone: "Asia/Tokyo"
+    cooldown:
+      default-days: 2
+    allow:
+      - dependency-type: direct
+    open-pull-requests-limit: 10

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,5 +34,8 @@ jobs:
       - name: Run linter
         run: deno lint --rules-exclude=no-slow-types
 
+      - name: Build
+        run: deno task build
+
       - name: Run tests
         run: deno task test

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,0 +1,21 @@
+name: Dependabot Auto-merge
+
+on:
+  pull_request:
+    types:
+      - opened
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto_merge:
+    name: Auto-merge
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+
+    steps:
+      - uses: fastify/github-action-merge-dependabot@v3
+        with:
+          use-github-auto-merge: true


### PR DESCRIPTION
## Summary

- add daily Dependabot updates for direct Deno dependencies
- wait two days after dependency releases before proposing updates
- enable auto-merge for Dependabot pull requests