### PR TITLE
Add volume and pan segments to notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,19 +344,21 @@ than toggled.
 
 ### `PxtoneNote`
 
-Each note corresponds to one note-on event. Pitch changes during the note are represented by
-`pitchSegments`. Notes belonging to the same unit never overlap: if the next note-on arrives before
-the current note is over, the current note is cut short at that tick.
+Each note corresponds to one note-on event. Pitch, volume, and stereo-pan changes during the note
+are represented by segments. Notes belonging to the same unit never overlap: if the next note-on
+arrives before the current note is over, the current note is cut short at that tick.
 
-| Property        | Type                            | Description                  |
-| --------------- | ------------------------------- | ---------------------------- |
-| `unit`          | `PxtoneUnit`                    | Instrument track             |
-| `startTick`     | `number`                        | Start position in ticks      |
-| `endTick`       | `number`                        | End position in ticks        |
-| `startTime`     | `number`                        | Start position in seconds    |
-| `endTime`       | `number`                        | End position in seconds      |
-| `velocity`      | `number`                        | Attack strength (0–128)      |
-| `pitchSegments` | `readonly PxtonePitchSegment[]` | Pitch movement over the note |
+| Property            | Type                                | Description                       |
+| ------------------- | ----------------------------------- | --------------------------------- |
+| `unit`              | `PxtoneUnit`                        | Instrument track                  |
+| `startTick`         | `number`                            | Start position in ticks           |
+| `endTick`           | `number`                            | End position in ticks             |
+| `startTime`         | `number`                            | Start position in seconds         |
+| `endTime`           | `number`                            | End position in seconds           |
+| `velocity`          | `number`                            | Attack strength (0–128)           |
+| `pitchSegments`     | `readonly PxtonePitchSegment[]`     | Pitch movement over the note      |
+| `volumeSegments`    | `readonly PxtoneVolumeSegment[]`    | Volume over the note              |
+| `panVolumeSegments` | `readonly PxtonePanVolumeSegment[]` | Stereo pan position over the note |
 
 #### `PxtonePitchSegment`
 
@@ -382,6 +384,33 @@ visualization; tuning events and sample-level integer rounding are not included.
 portamento completes; then `endKey` is the interpolated pitch reached so far while `targetKey` stays
 the key that was written. Renderers that snap a note to a single key row want `targetKey`; renderers
 that draw the glide want `endKey`.
+
+#### `PxtoneVolumeSegment`
+
+| Property    | Type     | Description                                   |
+| ----------- | -------- | --------------------------------------------- |
+| `startTick` | `number` | Segment start in ticks                        |
+| `endTick`   | `number` | Segment end in ticks                          |
+| `startTime` | `number` | Segment start in seconds                      |
+| `endTime`   | `number` | Segment end in seconds                        |
+| `value`     | `number` | Native pxtone volume                          |
+| `gain`      | `number` | Gain multiplier, normally 0–1 (`value / 128`) |
+
+#### `PxtonePanVolumeSegment`
+
+| Property    | Type     | Description                                     |
+| ----------- | -------- | ----------------------------------------------- |
+| `startTick` | `number` | Segment start in ticks                          |
+| `endTick`   | `number` | Segment end in ticks                            |
+| `startTime` | `number` | Segment start in seconds                        |
+| `endTime`   | `number` | Segment end in seconds                          |
+| `value`     | `number` | Native pxtone pan volume                        |
+| `pan`       | `number` | Pan position (`-1` left, `0` center, `1` right) |
+
+Volume and pan-volume events change their value immediately rather than interpolating. Each array is
+chronological and covers the note without gaps. Values set before a note are carried into its first
+segment. Volume defaults to `104`; pan volume defaults to `64` and ranges from `0` (left) to `64`
+(center) to `128` (right).
 
 ## WebAssembly
 

--- a/src/Pxtone.ts
+++ b/src/Pxtone.ts
@@ -230,7 +230,7 @@ export class PxtoneEvent {
   static get KIND_KEY(): 2 {
     return 2;
   }
-  /** Pan (stereo position). `value` ranges from 0 (left) to 128 (center) to 256 (right). */
+  /** Pan (stereo position). `value` ranges from 0 (left) to 64 (center) to 128 (right). */
   static get KIND_PAN_VOLUME(): 3 {
     return 3;
   }
@@ -459,6 +459,140 @@ export class PxtonePitchSegment {
   }
 }
 
+/** A constant volume interval within a {@link PxtoneNote}. */
+export class PxtoneVolumeSegment {
+  readonly #startTick: number;
+  readonly #endTick: number;
+  readonly #value: number;
+  readonly #timing: NoteTiming;
+
+  private constructor(
+    key: typeof illegalConstructorKey,
+    startTick: number,
+    endTick: number,
+    value: number,
+    timing: NoteTiming,
+  ) {
+    if (key !== illegalConstructorKey) {
+      throw new TypeError("Illegal constructor");
+    }
+    this.#startTick = startTick;
+    this.#endTick = endTick;
+    this.#value = value;
+    this.#timing = timing;
+  }
+
+  get startTick(): number {
+    return this.#startTick;
+  }
+
+  get endTick(): number {
+    return this.#endTick;
+  }
+
+  get startTime(): number {
+    return this.#startTick * this.#timing.secondsPerTick;
+  }
+
+  get endTime(): number {
+    return this.#endTick * this.#timing.secondsPerTick;
+  }
+
+  get value(): number {
+    return this.#value;
+  }
+
+  /** Volume as a gain multiplier, where the usual pxtone range 0–128 maps to 0–1. */
+  get gain(): number {
+    return this.#value / 128;
+  }
+
+  toJSON(): {
+    startTick: number;
+    endTick: number;
+    startTime: number;
+    endTime: number;
+    value: number;
+    gain: number;
+  } {
+    return {
+      startTick: this.#startTick,
+      endTick: this.#endTick,
+      startTime: this.startTime,
+      endTime: this.endTime,
+      value: this.#value,
+      gain: this.gain,
+    };
+  }
+}
+
+/** A constant stereo-pan interval within a {@link PxtoneNote}. */
+export class PxtonePanVolumeSegment {
+  readonly #startTick: number;
+  readonly #endTick: number;
+  readonly #value: number;
+  readonly #timing: NoteTiming;
+
+  private constructor(
+    key: typeof illegalConstructorKey,
+    startTick: number,
+    endTick: number,
+    value: number,
+    timing: NoteTiming,
+  ) {
+    if (key !== illegalConstructorKey) {
+      throw new TypeError("Illegal constructor");
+    }
+    this.#startTick = startTick;
+    this.#endTick = endTick;
+    this.#value = value;
+    this.#timing = timing;
+  }
+
+  get startTick(): number {
+    return this.#startTick;
+  }
+
+  get endTick(): number {
+    return this.#endTick;
+  }
+
+  get startTime(): number {
+    return this.#startTick * this.#timing.secondsPerTick;
+  }
+
+  get endTime(): number {
+    return this.#endTick * this.#timing.secondsPerTick;
+  }
+
+  get value(): number {
+    return this.#value;
+  }
+
+  /** Pan position, where the usual pxtone range 0–64–128 maps to left −1–0–right +1. */
+  get pan(): number {
+    return (this.#value - 64) / 64;
+  }
+
+  toJSON(): {
+    startTick: number;
+    endTick: number;
+    startTime: number;
+    endTime: number;
+    value: number;
+    pan: number;
+  } {
+    return {
+      startTick: this.#startTick,
+      endTick: this.#endTick,
+      startTime: this.startTime,
+      endTime: this.endTime,
+      value: this.#value,
+      pan: this.pan,
+    };
+  }
+}
+
 /**
  * A note-on interval and its pitch movement over time.
  *
@@ -472,6 +606,8 @@ export class PxtoneNote {
   readonly #endTick: number;
   readonly #velocity: number;
   readonly #pitchSegments: readonly PxtonePitchSegment[];
+  readonly #volumeSegments: readonly PxtoneVolumeSegment[];
+  readonly #panVolumeSegments: readonly PxtonePanVolumeSegment[];
   readonly #timing: NoteTiming;
 
   private constructor(
@@ -481,6 +617,8 @@ export class PxtoneNote {
     endTick: number,
     velocity: number,
     pitchSegments: readonly PxtonePitchSegment[],
+    volumeSegments: readonly PxtoneVolumeSegment[],
+    panVolumeSegments: readonly PxtonePanVolumeSegment[],
     timing: NoteTiming,
   ) {
     if (key !== illegalConstructorKey) {
@@ -491,6 +629,8 @@ export class PxtoneNote {
     this.#endTick = endTick;
     this.#velocity = velocity;
     this.#pitchSegments = pitchSegments;
+    this.#volumeSegments = volumeSegments;
+    this.#panVolumeSegments = panVolumeSegments;
     this.#timing = timing;
   }
 
@@ -527,6 +667,16 @@ export class PxtoneNote {
     return this.#pitchSegments;
   }
 
+  /** Volume over the note, in chronological, gap-free constant-value segments. */
+  get volumeSegments(): readonly PxtoneVolumeSegment[] {
+    return this.#volumeSegments;
+  }
+
+  /** Stereo pan over the note, in chronological, gap-free constant-value segments. */
+  get panVolumeSegments(): readonly PxtonePanVolumeSegment[] {
+    return this.#panVolumeSegments;
+  }
+
   toJSON(): {
     unit: PxtoneUnit;
     startTick: number;
@@ -535,6 +685,8 @@ export class PxtoneNote {
     endTime: number;
     velocity: number;
     pitchSegments: readonly PxtonePitchSegment[];
+    volumeSegments: readonly PxtoneVolumeSegment[];
+    panVolumeSegments: readonly PxtonePanVolumeSegment[];
   } {
     return {
       unit: this.#unit,
@@ -544,6 +696,8 @@ export class PxtoneNote {
       endTime: this.endTime,
       velocity: this.#velocity,
       pitchSegments: this.#pitchSegments,
+      volumeSegments: this.#volumeSegments,
+      panVolumeSegments: this.#panVolumeSegments,
     };
   }
 }
@@ -887,7 +1041,7 @@ export class Pxtone {
   }
 
   /**
-   * Notes in the loaded song, including constant and portamento pitch segments.
+   * Notes in the loaded song, including pitch, volume, and stereo-pan segments.
    *
    * Ordered by {@link PxtoneNote.startTick}; notes starting on the same tick follow the order
    * of {@link units}. Drawing them in this order therefore starts earlier notes first.
@@ -1347,7 +1501,35 @@ export class Pxtone {
           timing,
         );
       },
-      createNote(unit, startTick, endTick, velocity, pitchSegments) {
+      createVolumeSegment(startTick, endTick, value) {
+        // @ts-expect-error: allow private constructor
+        return new PxtoneVolumeSegment(
+          illegalConstructorKey,
+          startTick,
+          endTick,
+          value,
+          timing,
+        );
+      },
+      createPanVolumeSegment(startTick, endTick, value) {
+        // @ts-expect-error: allow private constructor
+        return new PxtonePanVolumeSegment(
+          illegalConstructorKey,
+          startTick,
+          endTick,
+          value,
+          timing,
+        );
+      },
+      createNote(
+        unit,
+        startTick,
+        endTick,
+        velocity,
+        pitchSegments,
+        volumeSegments,
+        panVolumeSegments,
+      ) {
         // @ts-expect-error: allow private constructor
         return new PxtoneNote(
           illegalConstructorKey,
@@ -1356,6 +1538,8 @@ export class Pxtone {
           endTick,
           velocity,
           Object.freeze(pitchSegments),
+          Object.freeze(volumeSegments),
+          Object.freeze(panVolumeSegments),
           timing,
         );
       },

--- a/src/notes.ts
+++ b/src/notes.ts
@@ -1,17 +1,23 @@
 import type {
   PxtoneEvent,
   PxtoneNote,
+  PxtonePanVolumeSegment,
   PxtonePitchInterpolation,
   PxtonePitchSegment,
   PxtoneUnit,
+  PxtoneVolumeSegment,
 } from "./Pxtone.ts";
 
 const DEFAULT_KEY = 0x6000;
 const DEFAULT_VELOCITY = 104;
+const DEFAULT_VOLUME = 104;
+const DEFAULT_PAN_VOLUME = 64;
 
 const KIND_ON = 1;
 const KIND_KEY = 2;
+const KIND_PAN_VOLUME = 3;
 const KIND_VELOCITY = 4;
+const KIND_VOLUME = 5;
 const KIND_PORTAMENT = 6;
 
 interface NoteFactory {
@@ -23,12 +29,20 @@ interface NoteFactory {
     targetKey: number,
     interpolation: PxtonePitchInterpolation,
   ): PxtonePitchSegment;
+  createVolumeSegment(startTick: number, endTick: number, value: number): PxtoneVolumeSegment;
+  createPanVolumeSegment(
+    startTick: number,
+    endTick: number,
+    value: number,
+  ): PxtonePanVolumeSegment;
   createNote(
     unit: PxtoneUnit,
     startTick: number,
     endTick: number,
     velocity: number,
     pitchSegments: PxtonePitchSegment[],
+    volumeSegments: PxtoneVolumeSegment[],
+    panVolumeSegments: PxtonePanVolumeSegment[],
   ): PxtoneNote;
 }
 
@@ -44,8 +58,12 @@ interface MutableNote {
   startTick: number;
   endTick: number;
   velocity: number;
-  cursorTick: number;
+  pitchCursorTick: number;
+  volumeCursorTick: number;
+  panVolumeCursorTick: number;
   pitchSegments: PxtonePitchSegment[];
+  volumeSegments: PxtoneVolumeSegment[];
+  panVolumeSegments: PxtonePanVolumeSegment[];
 }
 
 function keyAt(glide: Glide | null, holdKey: number, tick: number): number {
@@ -69,7 +87,7 @@ function appendPitchSegments(
   holdKey: number,
   factory: NoteFactory,
 ): void {
-  let startTick = note.cursorTick;
+  let startTick = note.pitchCursorTick;
   if (endTick <= startTick) {
     return;
   }
@@ -104,7 +122,31 @@ function appendPitchSegments(
       factory.createPitchSegment(startTick, endTick, key, key, key, "hold"),
     );
   }
-  note.cursorTick = endTick;
+  note.pitchCursorTick = endTick;
+}
+
+function appendVolumeSegment(
+  segments: PxtoneVolumeSegment[],
+  startTick: number,
+  endTick: number,
+  value: number,
+  factory: NoteFactory,
+): void {
+  if (startTick < endTick) {
+    segments.push(factory.createVolumeSegment(startTick, endTick, value));
+  }
+}
+
+function appendPanVolumeSegment(
+  segments: PxtonePanVolumeSegment[],
+  startTick: number,
+  endTick: number,
+  value: number,
+  factory: NoteFactory,
+): void {
+  if (startTick < endTick) {
+    segments.push(factory.createPanVolumeSegment(startTick, endTick, value));
+  }
 }
 
 function finishNote(
@@ -112,10 +154,26 @@ function finishNote(
   endTick: number,
   glide: Glide | null,
   holdKey: number,
+  volume: number,
+  panVolume: number,
   factory: NoteFactory,
 ): PxtoneNote | null {
   const clippedEnd = Math.min(note.endTick, endTick);
   appendPitchSegments(note, clippedEnd, glide, holdKey, factory);
+  appendVolumeSegment(
+    note.volumeSegments,
+    note.volumeCursorTick,
+    clippedEnd,
+    volume,
+    factory,
+  );
+  appendPanVolumeSegment(
+    note.panVolumeSegments,
+    note.panVolumeCursorTick,
+    clippedEnd,
+    panVolume,
+    factory,
+  );
   if (clippedEnd <= note.startTick) {
     return null;
   }
@@ -125,12 +183,14 @@ function finishNote(
     clippedEnd,
     note.velocity,
     note.pitchSegments,
+    note.volumeSegments,
+    note.panVolumeSegments,
   );
 }
 
 /**
- * @internal Converts events ordered by tick and pxtone event priority into note and
- * pitch-segment objects.
+ * @internal Converts events ordered by tick and pxtone event priority into notes and their
+ * pitch and value segments.
  */
 export function buildNotes(
   units: readonly PxtoneUnit[],
@@ -150,6 +210,8 @@ export function buildNotes(
   for (let unitIndex = 0; unitIndex < unitEvents.length; unitIndex++) {
     let holdKey = DEFAULT_KEY;
     let velocity = DEFAULT_VELOCITY;
+    let volume = DEFAULT_VOLUME;
+    let panVolume = DEFAULT_PAN_VOLUME;
     let portamento = 0;
     let glide: Glide | null = null;
     let activeNote: MutableNote | null = null;
@@ -161,6 +223,8 @@ export function buildNotes(
           activeNote.endTick,
           glide,
           holdKey,
+          volume,
+          panVolume,
           factory,
         );
         if (note !== null) {
@@ -170,9 +234,39 @@ export function buildNotes(
       }
 
       switch (event.kind) {
-        case KIND_PORTAMENT:
-          portamento = Math.max(0, event.value);
+        case KIND_ON: {
+          if (activeNote !== null) {
+            const note = finishNote(
+              activeNote,
+              event.tick,
+              glide,
+              holdKey,
+              volume,
+              panVolume,
+              factory,
+            );
+            if (note !== null) {
+              notes.push({ note, unitIndex });
+            }
+          }
+          holdKey = glide?.endKey ?? holdKey;
+          glide = null;
+          activeNote = event.value > 0
+            ? {
+              unit: units[unitIndex],
+              startTick: event.tick,
+              endTick: event.tick + event.value,
+              velocity,
+              pitchCursorTick: event.tick,
+              volumeCursorTick: event.tick,
+              panVolumeCursorTick: event.tick,
+              pitchSegments: [],
+              volumeSegments: [],
+              panVolumeSegments: [],
+            }
+            : null;
           break;
+        }
         case KIND_KEY: {
           if (activeNote !== null) {
             appendPitchSegments(activeNote, event.tick, glide, holdKey, factory);
@@ -192,29 +286,41 @@ export function buildNotes(
           }
           break;
         }
-        case KIND_ON: {
-          if (activeNote !== null) {
-            const note = finishNote(activeNote, event.tick, glide, holdKey, factory);
-            if (note !== null) {
-              notes.push({ note, unitIndex });
+        case KIND_PAN_VOLUME:
+          if (event.value !== panVolume) {
+            if (activeNote !== null) {
+              appendPanVolumeSegment(
+                activeNote.panVolumeSegments,
+                activeNote.panVolumeCursorTick,
+                event.tick,
+                panVolume,
+                factory,
+              );
+              activeNote.panVolumeCursorTick = event.tick;
             }
+            panVolume = event.value;
           }
-          holdKey = glide?.endKey ?? holdKey;
-          glide = null;
-          activeNote = event.value > 0
-            ? {
-              unit: units[unitIndex],
-              startTick: event.tick,
-              endTick: event.tick + event.value,
-              velocity,
-              cursorTick: event.tick,
-              pitchSegments: [],
-            }
-            : null;
           break;
-        }
         case KIND_VELOCITY:
           velocity = event.value;
+          break;
+        case KIND_VOLUME:
+          if (event.value !== volume) {
+            if (activeNote !== null) {
+              appendVolumeSegment(
+                activeNote.volumeSegments,
+                activeNote.volumeCursorTick,
+                event.tick,
+                volume,
+                factory,
+              );
+              activeNote.volumeCursorTick = event.tick;
+            }
+            volume = event.value;
+          }
+          break;
+        case KIND_PORTAMENT:
+          portamento = Math.max(0, event.value);
           break;
       }
     }
@@ -225,6 +331,8 @@ export function buildNotes(
         activeNote.endTick,
         glide,
         holdKey,
+        volume,
+        panVolume,
         factory,
       );
       if (note !== null) {

--- a/tests/notes_test.ts
+++ b/tests/notes_test.ts
@@ -4,14 +4,18 @@ import { buildNotes } from "../src/notes.ts";
 import type {
   PxtoneEvent,
   PxtoneNote,
+  PxtonePanVolumeSegment,
   PxtonePitchInterpolation,
   PxtonePitchSegment,
   PxtoneUnit,
+  PxtoneVolumeSegment,
 } from "../src/Pxtone.ts";
 
-const KEY = 2;
 const ON = 1;
+const KEY = 2;
+const PAN_VOLUME = 3;
 const VELOCITY = 4;
+const VOLUME = 5;
 const PORTAMENT = 6;
 
 const factory = {
@@ -32,14 +36,34 @@ const factory = {
       interpolation,
     } as unknown as PxtonePitchSegment;
   },
+  createVolumeSegment(startTick: number, endTick: number, value: number): PxtoneVolumeSegment {
+    return { startTick, endTick, value } as unknown as PxtoneVolumeSegment;
+  },
+  createPanVolumeSegment(
+    startTick: number,
+    endTick: number,
+    value: number,
+  ): PxtonePanVolumeSegment {
+    return { startTick, endTick, value } as unknown as PxtonePanVolumeSegment;
+  },
   createNote(
     unit: PxtoneUnit,
     startTick: number,
     endTick: number,
     velocity: number,
     pitchSegments: PxtonePitchSegment[],
+    volumeSegments: PxtoneVolumeSegment[],
+    panVolumeSegments: PxtonePanVolumeSegment[],
   ): PxtoneNote {
-    return { unit, startTick, endTick, velocity, pitchSegments } as unknown as PxtoneNote;
+    return {
+      unit,
+      startTick,
+      endTick,
+      velocity,
+      pitchSegments,
+      volumeSegments,
+      panVolumeSegments,
+    } as unknown as PxtoneNote;
   },
 };
 
@@ -65,6 +89,12 @@ function pitchSegmentsOf(note: PxtoneNote) {
     targetKey: segment.targetKey,
     interpolation: segment.interpolation,
   }));
+}
+
+function volumeSegmentsOf(
+  segments: readonly (PxtoneVolumeSegment | PxtonePanVolumeSegment)[],
+) {
+  return segments.map((segment) => [segment.startTick, segment.endTick, segment.value]);
 }
 
 Deno.test("buildNotes creates hold and portamento segments", () => {
@@ -177,6 +207,36 @@ Deno.test("buildNotes keeps the written key when a note ends mid-glide", () => {
       interpolation: "linear",
     },
   ]);
+});
+
+Deno.test("buildNotes clips volume and pan automation to each note", () => {
+  const unit = testUnit("lead");
+  const notes = buildNotes(
+    [unit],
+    [
+      event(unit, 10, VOLUME, 80),
+      event(unit, 20, PAN_VOLUME, 32),
+      event(unit, 30, ON, 100),
+      event(unit, 50, VOLUME, 64),
+      event(unit, 70, VOLUME, 64), // Repeated values do not split the segment.
+      event(unit, 90, PAN_VOLUME, 96),
+      event(unit, 110, VOLUME, 104),
+      event(unit, 140, ON, 20),
+    ],
+    factory,
+  );
+
+  assertEquals(volumeSegmentsOf(notes[0].volumeSegments), [
+    [30, 50, 80],
+    [50, 110, 64],
+    [110, 130, 104],
+  ]);
+  assertEquals(volumeSegmentsOf(notes[0].panVolumeSegments), [
+    [30, 90, 32],
+    [90, 130, 96],
+  ]);
+  assertEquals(volumeSegmentsOf(notes[1].volumeSegments), [[140, 160, 104]]);
+  assertEquals(volumeSegmentsOf(notes[1].panVolumeSegments), [[140, 160, 96]]);
 });
 
 Deno.test("buildNotes truncates overlapping notes and sorts units chronologically", () => {

--- a/tests/pxtone_test.ts
+++ b/tests/pxtone_test.ts
@@ -10,7 +10,14 @@ import {
 } from "@std/assert";
 import { parse as parseToml } from "@std/toml";
 
-import { Pxtone, PxtoneError, PxtoneNote, PxtonePitchSegment } from "../src/Pxtone.ts";
+import {
+  Pxtone,
+  PxtoneError,
+  PxtoneNote,
+  PxtonePanVolumeSegment,
+  PxtonePitchSegment,
+  PxtoneVolumeSegment,
+} from "../src/Pxtone.ts";
 
 const projectRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
 
@@ -379,7 +386,11 @@ Deno.test("Pxtone getters are guarded by state", async () => {
   assert(Object.isFrozen(pxtone.notes));
   assert(pxtone.notes[0] instanceof PxtoneNote);
   assert(Object.isFrozen(pxtone.notes[0].pitchSegments));
+  assert(Object.isFrozen(pxtone.notes[0].volumeSegments));
+  assert(Object.isFrozen(pxtone.notes[0].panVolumeSegments));
   assert(pxtone.notes[0].pitchSegments[0] instanceof PxtonePitchSegment);
+  assert(pxtone.notes[0].volumeSegments[0] instanceof PxtoneVolumeSegment);
+  assert(pxtone.notes[0].panVolumeSegments[0] instanceof PxtonePanVolumeSegment);
   const firstNote = pxtone.notes[0];
   const firstSegment = firstNote.pitchSegments[0];
   const secondsPerTick = 60 / (pxtone.beatTempo! * pxtone.ticksPerBeat!);
@@ -389,6 +400,12 @@ Deno.test("Pxtone getters are guarded by state", async () => {
   assertEquals(firstSegment.endTime, firstSegment.endTick * secondsPerTick);
   assertEquals(firstSegment.startPitch, firstSegment.startKey / 256);
   assertEquals(firstSegment.endPitch, firstSegment.endKey / 256);
+  const firstVolumeSegment = firstNote.volumeSegments[0];
+  assertEquals(firstVolumeSegment.startTime, firstVolumeSegment.startTick * secondsPerTick);
+  assertEquals(firstVolumeSegment.endTime, firstVolumeSegment.endTick * secondsPerTick);
+  assertEquals(firstVolumeSegment.gain, firstVolumeSegment.value / 128);
+  const firstPanVolumeSegment = firstNote.panVolumeSegments[0];
+  assertEquals(firstPanVolumeSegment.pan, (firstPanVolumeSegment.value - 64) / 64);
 
   // --- streaming ---
 


### PR DESCRIPTION
## Summary

- expose note-scoped volume and pan-volume automation as gap-free segments
- add normalized `gain` and `pan` getters while preserving native pxtone values
- document the new APIs and correct the PAN_VOLUME range

## Validation

- `deno check src/Pxtone.ts`
- `deno lint src/ tests/`
- `deno task test` (12 passed)
- `deno task build`
- `deno publish --dry-run --allow-dirty`