### PR TITLE
chore: update GitHub Actions with Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,3 +11,13 @@ updates:
     allow:
       - dependency-type: direct
     open-pull-requests-limit: 10
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: daily
+      time: "08:00"
+      timezone: "Asia/Tokyo"
+    cooldown:
+      default-days: 2
+    open-pull-requests-limit: 10


### PR DESCRIPTION
## Summary

- enable Dependabot updates for GitHub Actions
- use the existing daily 08:00 JST schedule and two-day cooldown
- keep action updates in individual pull requests

## Validation

- `deno fmt --check .github/dependabot.yml`
- `git diff --check`