### PR TITLE
Take a note's velocity from the event written with its note-on

### DIFF
--- a/README.md
+++ b/README.md
@@ -360,6 +360,10 @@ arrives before the current note is over, the current note is cut short at that t
 | `volumeSegments`    | `readonly PxtoneVolumeSegment[]`    | Volume over the note              |
 | `panVolumeSegments` | `readonly PxtonePanVolumeSegment[]` | Stereo pan position over the note |
 
+`velocity` is the value written alongside the note-on, which is how pxtone stores the velocity of a
+note. A note with no velocity event of its own keeps whichever value was still in effect, starting
+from the default of `104`.
+
 #### `PxtonePitchSegment`
 
 | Property        | Type                 | Description                                     |

--- a/src/notes.ts
+++ b/src/notes.ts
@@ -125,6 +125,28 @@ function appendPitchSegments(
   note.pitchCursorTick = endTick;
 }
 
+/**
+ * The velocity a note starting at `events[index]` sounds with.
+ *
+ * pxtone writes the velocity of a note alongside its note-on, but event priority orders velocity
+ * after note-on, so the running value has not caught up yet when the note begins. Volume and pan
+ * volume do not need this: their same-tick event closes a zero-length segment, which is dropped,
+ * and the new value carries into the note's first segment.
+ */
+function velocityAtNoteOn(
+  events: readonly PxtoneEvent[],
+  index: number,
+  velocity: number,
+): number {
+  const { tick } = events[index];
+  for (let i = index + 1; i < events.length && events[i].tick === tick; i++) {
+    if (events[i].kind === KIND_VELOCITY) {
+      velocity = events[i].value;
+    }
+  }
+  return velocity;
+}
+
 function appendVolumeSegment(
   segments: PxtoneVolumeSegment[],
   startTick: number,
@@ -216,7 +238,9 @@ export function buildNotes(
     let glide: Glide | null = null;
     let activeNote: MutableNote | null = null;
 
-    for (const event of unitEvents[unitIndex]) {
+    const events = unitEvents[unitIndex];
+    for (let eventIndex = 0; eventIndex < events.length; eventIndex++) {
+      const event = events[eventIndex];
       if (activeNote !== null && activeNote.endTick <= event.tick) {
         const note = finishNote(
           activeNote,
@@ -256,7 +280,7 @@ export function buildNotes(
               unit: units[unitIndex],
               startTick: event.tick,
               endTick: event.tick + event.value,
-              velocity,
+              velocity: velocityAtNoteOn(events, eventIndex, velocity),
               pitchCursorTick: event.tick,
               volumeCursorTick: event.tick,
               panVolumeCursorTick: event.tick,

--- a/tests/notes_test.ts
+++ b/tests/notes_test.ts
@@ -112,7 +112,7 @@ Deno.test("buildNotes creates hold and portamento segments", () => {
   );
 
   assertEquals(notes.length, 1);
-  assertEquals(notes[0].velocity, 104); // VELOCITY follows ON at the same tick.
+  assertEquals(notes[0].velocity, 80); // the velocity written alongside the note-on
   assertEquals(pitchSegmentsOf(notes[0]), [
     {
       startTick: 0,
@@ -171,6 +171,29 @@ Deno.test("buildNotes restarts an interrupted glide from its current pitch", () 
       { ticks: [200, 300], keys: [0x6800, 0x6800], targetKey: 0x6800, interpolation: "hold" },
     ],
   );
+});
+
+Deno.test("buildNotes takes the velocity written alongside each note-on", () => {
+  const unit = testUnit("lead");
+  const notes = buildNotes(
+    [unit],
+    [
+      // pxtone writes one velocity event per note, at the note's own tick, and event
+      // priority places it after the note-on.
+      event(unit, 0, KEY, 0x6000),
+      event(unit, 0, ON, 100),
+      event(unit, 0, VELOCITY, 40),
+      event(unit, 100, KEY, 0x6000),
+      event(unit, 100, ON, 100),
+      event(unit, 100, VELOCITY, 120),
+      // A note with no velocity event of its own keeps the value still in effect.
+      event(unit, 200, KEY, 0x6000),
+      event(unit, 200, ON, 100),
+    ],
+    factory,
+  );
+
+  assertEquals(notes.map((note) => note.velocity), [40, 120, 120]);
 });
 
 Deno.test("buildNotes keeps the written key when a note ends mid-glide", () => {


### PR DESCRIPTION
## The bug

pxtone stores the velocity of a note as a velocity event at the note's own tick. But `PXTONE_EVENT_PRIORITY` orders velocity (70) after note-on (50), so when `buildNotes` created the note it read the running `velocity` variable before that event had been applied — and picked up whatever the *previous* note had left behind.

## How wrong it was

Measured across 23 songs collected from [ptweb.me](https://www.ptweb.me/):

| | |
| --- | --- |
| notes | 46,387 |
| notes with a velocity event at their own tick | 46,386 (**100.0%**) |
| of those, `note.velocity` disagreed with it | 6,659 (**14.4%**) |
| median / max disagreement | **24** / 110, on a 0–128 scale |

A quarter of the velocity range is audible in a synth driven from `notes`, and visible in a piano roll that shades notes by velocity. After this change the disagreement count is 0.

This turned up while porting [ptweb](https://github.com/yuxshao/ptweb)'s piano roll from its own event-list walk to `notes`: notes came out at noticeably different brightness from what the old renderer drew.

## The fix

At a note-on, look ahead through the events remaining at that same tick for a velocity event and use it. Events are already grouped by tick and ordered by priority, so this only scans the handful of events sharing the note's tick.

Volume and pan volume did not need this, and the new comment says so: their same-tick event closes a zero-length segment, which `appendVolumeSegment` drops, so the new value carries into the note's first segment anyway.

## Tests

`deno task test` — 13 passed, 0 failed.

Adds `buildNotes takes the velocity written alongside each note-on`, covering both a note with its own velocity event and one without. The existing assertion in `buildNotes creates hold and portamento segments` pinned the old behaviour (`104`, with the comment "VELOCITY follows ON at the same tick") and now expects the written `80`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)