### PR TITLE
Fix the sourcemaps broken by the bundle post-processing

### DIFF
--- a/tools/build_dts.ts
+++ b/tools/build_dts.ts
@@ -45,12 +45,3 @@ await Deno.remove(tempDir, { recursive: true });
 const outPath = join(projectRoot, "bundle", "Pxtone.d.mts");
 await Deno.writeTextFile(outPath, dtsContent);
 console.log(`Generated ${outPath}`);
-
-const mjsPath = join(projectRoot, "bundle", "Pxtone.mjs");
-const mjsContent = await Deno.readTextFile(mjsPath);
-const endOfComment = mjsContent.indexOf("*/") + 2;
-const newContent = mjsContent.slice(0, endOfComment) +
-  '\n// @ts-self-types="./Pxtone.d.mts"' +
-  mjsContent.slice(endOfComment);
-await Deno.writeTextFile(mjsPath, newContent);
-console.log(`Updated ${mjsPath} with @ts-types directive`);

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,4 +1,5 @@
-import { readFileSync } from "node:fs";
+import { readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
 
 import { defineConfig } from "vite";
 
@@ -51,30 +52,38 @@ ${namedExports}`;
   };
 }
 
+// rolldown strips the indentation of `output.banner` and of anything renderChunk returns, and
+// renderChunk without a sourcemap warns [SOURCEMAP_BROKEN], so prepend the banner to the written
+// files and shift the sourcemap by the number of added lines
 function bannerPlugin(banner: string) {
   return {
     name: "banner",
-    generateBundle(
-      _opts: unknown,
-      bundle: Record<string, { type: string; code?: string }>,
+    writeBundle(
+      options: { dir?: string; format?: string },
+      bundle: Record<string, { type: string; fileName: string; sourcemapFileName?: string }>,
     ) {
-      for (const chunk of Object.values(bundle)) {
-        if (chunk.type === "chunk" && chunk.code !== undefined) {
-          chunk.code = banner + "\n" + chunk.code;
-        }
-      }
-    },
-  };
-}
+      const { dir, format } = options;
+      if (dir === undefined) return;
 
-function stripCommentsPlugin() {
-  return {
-    name: "strip-comments",
-    renderChunk(code: string) {
-      return code
-        .replace(/\/\*\*[\s\S]*?\*\//g, "")
-        .replace(/^\s*\/\/#(end)?region.*\n?/gm, "")
-        .replace(/\n{3,}/g, "\n\n");
+      // the ES bundle also points at its type definitions
+      const text = format === "es"
+        ? `${banner}\n// @ts-self-types="./Pxtone.d.mts"\n`
+        : `${banner}\n`;
+      const emptyLines = ";".repeat(text.split("\n").length - 1);
+
+      for (const chunk of Object.values(bundle)) {
+        if (chunk.type !== "chunk") continue;
+
+        const codePath = join(dir, chunk.fileName);
+        writeFileSync(codePath, text + readFileSync(codePath, "utf-8"));
+
+        const { sourcemapFileName } = chunk;
+        if (sourcemapFileName === undefined) continue;
+        const mapPath = join(dir, sourcemapFileName);
+        const map = JSON.parse(readFileSync(mapPath, "utf-8")) as { mappings: string };
+        map.mappings = emptyLines + map.mappings;
+        writeFileSync(mapPath, JSON.stringify(map));
+      }
     },
   };
 }
@@ -82,7 +91,6 @@ function stripCommentsPlugin() {
 export default defineConfig({
   plugins: [
     wasmInstancePlugin(),
-    stripCommentsPlugin(),
     bannerPlugin(banner),
   ],
   build: {
@@ -93,17 +101,23 @@ export default defineConfig({
     emptyOutDir: false,
     minify: false,
     sourcemap: true,
-    rollupOptions: {
+    rolldownOptions: {
+      // drop the `//#region` comments
+      experimental: {
+        attachDebugInfo: "none",
+      },
       output: [
         {
           format: "es",
           entryFileNames: "Pxtone.mjs",
+          comments: { legal: false, jsdoc: false },
         },
         {
           format: "iife",
           entryFileNames: "Pxtone.js",
           name: "Pxtone",
           intro: '"use strict";',
+          comments: { legal: false, jsdoc: false },
         },
       ],
     },


### PR DESCRIPTION
`deno task build` started warning with `[SOURCEMAP_BROKEN]`:

```
[plugin strip-comments] [SOURCEMAP_BROKEN] Sourcemap is likely to be incorrect: a plugin (strip-comments) was used to transform files, but didn't generate a sourcemap for the transformation.
```

The `strip-comments` plugin rewrote each chunk in `renderChunk` with regular expressions but never returned a sourcemap, and the `banner` plugin prepended 14 lines in `generateBundle` without adjusting the mappings, so the emitted sourcemaps were off by the banner (silently, without any warning).

## Changes

- Remove `strip-comments`. The source comments are now dropped by rolldown's `output.comments`, and the `//#region` markers by `experimental.attachDebugInfo`
- Prepend the banner in `writeBundle` instead of `generateBundle`, and shift the sourcemap mappings by the number of added lines. Neither `output.banner` nor `renderChunk` can be used here: rolldown re-formats the chunk afterwards and strips the indentation of the license block, and mutating `chunk.map` in `generateBundle` has no effect on the emitted map
- Move the `@ts-self-types` directive from `tools/build_dts.ts` into the banner. Inserting it after the build shifted the file by one more line
- Rename the deprecated `build.rollupOptions` to `build.rolldownOptions`

## Verification

- `deno task build` no longer warns, and the bundle output is unchanged (banner indentation kept, no `//#region`, no leftover JSDoc)
- Decoding the emitted mappings now resolves to the right source lines, for both outputs:
  - `Pxtone.mjs:613 class Pxtone {` → `src/Pxtone.ts:765 export class Pxtone {`
  - `Pxtone.mjs:91 function buildNotes(` → `src/notes.ts:217 export function buildNotes(`
  - `Pxtone.mjs:16 function pcmToAudioData(` → `src/pcm.ts:4 export function pcmToAudioData(`
- `deno task test` (13 passed), `deno check vite.config.ts tools/build_dts.ts` and `deno task build:npm` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)