### PR TITLE
ci: squash-merge the release PR, generate release notes, and run CI on any base branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,8 +5,6 @@ on:
     branches:
       - main
   pull_request:
-    branches:
-      - main
 
 permissions:
   contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,31 +54,32 @@ jobs:
         working-directory: ./npm
 
       - name: Commit version bump
-        id: bump_commit
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git checkout -b "release/v${{ inputs.version }}"
           git commit -am "chore: bump version to v${{ inputs.version }}"
-          echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
           git push origin "release/v${{ inputs.version }}"
 
       - name: Open version bump PR
+        id: bump_pr
         env:
           GH_TOKEN: ${{ secrets.RELEASE_PAT }}
         run: |
-          gh pr create \
+          url=$(gh pr create \
             --base main \
             --head "release/v${{ inputs.version }}" \
             --title "chore: bump version to v${{ inputs.version }}" \
-            --body "Automated version bump for release v${{ inputs.version }}."
+            --body "Automated version bump for release v${{ inputs.version }}.")
+
+          echo "number=${url##*/}" >> "$GITHUB_OUTPUT"
 
       - name: Wait for checks to be registered
         env:
           GH_TOKEN: ${{ secrets.RELEASE_PAT }}
         run: |
           for i in {1..30}; do
-            count=$(gh pr checks "release/v${{ inputs.version }}" \
+            count=$(gh pr checks "${{ steps.bump_pr.outputs.number }}" \
               --required --json name --jq 'length' 2>/dev/null || true)
 
             if [ "$count" -gt 0 ]; then
@@ -95,16 +96,35 @@ jobs:
       - name: Wait for required checks
         env:
           GH_TOKEN: ${{ secrets.RELEASE_PAT }}
-        run: gh pr checks "release/v${{ inputs.version }}" --watch --required
+        run: gh pr checks "${{ steps.bump_pr.outputs.number }}" --watch --required
 
       - name: Merge version bump PR
+        id: bump_merge
         env:
           GH_TOKEN: ${{ secrets.RELEASE_PAT }}
-        run: gh pr merge "release/v${{ inputs.version }}" --merge --delete-branch
+        run: |
+          gh pr merge "${{ steps.bump_pr.outputs.number }}" --squash --delete-branch
+
+          for i in {1..30}; do
+            sha=$(gh pr view "${{ steps.bump_pr.outputs.number }}" \
+              --json mergeCommit --jq '.mergeCommit.oid // empty')
+
+            if [ -n "$sha" ]; then
+              echo "sha=$sha" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+
+            echo "Merge commit is not available yet ($i/30)"
+            sleep 2
+          done
+
+          echo "Timed out waiting for the merge commit"
+          exit 1
 
       - name: Tag version bump
         run: |
-          git tag "v${{ inputs.version }}" "${{ steps.bump_commit.outputs.sha }}"
+          git fetch origin "${{ steps.bump_merge.outputs.sha }}"
+          git tag "v${{ inputs.version }}" "${{ steps.bump_merge.outputs.sha }}"
           git push origin "v${{ inputs.version }}"
 
       - name: Create GitHub Release
@@ -112,3 +132,4 @@ jobs:
         with:
           tag_name: v${{ inputs.version }}
           files: bundle/*
+          generate_release_notes: true


### PR DESCRIPTION
## Summary

- Merge the version bump PR with `--squash` instead of `--merge`.
- Enable the default GitHub Releases note generator via `generate_release_notes: true`.
- Run the CI workflow on pull requests regardless of the base branch.

## Follow-up fixes required by the squash merge

- **Tag the right commit.** The workflow used to tag `git rev-parse HEAD`, i.e. the commit pushed to the `release/vX.Y.Z` branch. With a squash merge that commit never becomes part of `main`'s history, so the tag would point at a commit unreachable from `main`. The merge commit is now resolved from the PR (`gh pr view --json mergeCommit`, polled for up to 60s to absorb API lag) and the tag is placed there. `git fetch origin <sha>` was added since that commit is not in the checked-out history.
- **Identify the PR by number.** `gh pr create` now reports the PR number, which is used for the check-wait steps and the merge. Looking the PR up by branch name stops working once `--delete-branch` removes it.

## CI trigger

The `pull_request` base branch filter is dropped so that pull requests targeting a branch other than `main` are tested as well. The `push` trigger still fires on `main` only, so branch pushes are not built twice.

## Note

"Allow squash merging" must be enabled in the repository settings, otherwise `gh pr merge --squash` fails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)