### PR TITLE
Fix dts build on Deno 2.9.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,8 +20,7 @@ jobs:
       - name: Setup Deno
         uses: denoland/setup-deno@v2
         with:
-          # 2.9.6 breaks `deno transpile --declaration` (denoland/deno#36709)
-          deno-version: v2.9.5
+          deno-version: latest
           cache: true
 
       - name: Install Deno dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,8 +23,7 @@ jobs:
       - name: Setup Deno
         uses: denoland/setup-deno@v2
         with:
-          # 2.9.6 breaks `deno transpile --declaration` (denoland/deno#36709)
-          deno-version: v2.9.5
+          deno-version: latest
           cache: true
 
       - name: Setup Node.js

--- a/tools/build_dts.ts
+++ b/tools/build_dts.ts
@@ -26,6 +26,10 @@ const command = new Deno.Command(Deno.execPath(), {
     configPath,
     "--quiet",
   ],
+  // `transpile --declaration` still reads compilerOptions.lib from the cwd
+  // deno.json, even with `--config`. The project lib includes `deno.ns`, which
+  // on Deno 2.9.6 fails to resolve `node:net` / `NodeJS` (denoland/deno#36709).
+  cwd: tempDir,
   stderr: "inherit",
 });
 


### PR DESCRIPTION
`deno task build` failed on Deno 2.9.6 because `tools/build_dts.ts` runs `deno transpile --declaration` from the repo root.

This is not a universal 2.9.6 break. It happens when the cwd `deno.json` sets `compilerOptions.lib` to include `deno.ns` (this repo uses `["dom", "dom.iterable", "deno.ns"]` so tests can see `Deno.*` while `Pxtone.ts` sees DOM). On 2.9.6, `lib.deno.ns.d.ts` references `import("node:net")` and `NodeJS.Timeout`, but `transpile --declaration` does not load `lib.node`. Adding `"node"` to `lib` does not help. `--no-config` also does not help — the cwd config is still applied.

The tool already writes a temp config with `["dom", "dom.iterable", "esnext"]`. That override only takes effect if transpile is started in that temp directory. `cwd` is now that directory. Isolated repro: same `lib` in an empty folder fails; default libs / `deno.window` succeed.

CI/release Deno is unpinned back to `latest`.

See [denoland/deno#36709](https://github.com/denoland/deno/issues/36709).

Verified locally with Deno 2.9.6: `deno task build` and `deno task test` (13 passed).